### PR TITLE
Optional flag for failing on modified code tree

### DIFF
--- a/scm_source/api.py
+++ b/scm_source/api.py
@@ -26,9 +26,14 @@ def get_scm_source_data(author: str, directory: str=None):
     return data
 
 
-def generate_scm_source(path: str, author: str, directory: str=None):
+def generate_scm_source(path: str, author: str, directory: str=None, fail_on_modified: bool = False):
     '''Generate and write scm-source.json'''
     data = get_scm_source_data(author, directory)
+    is_locally_modified = data['status']
+
+    if is_locally_modified and fail_on_modified:
+        raise RuntimeError('Code tree has been modified')
+
     with open(path, 'w', encoding='utf-8') as fd:
         json.dump(data, fd)
-    return data['status']
+    return is_locally_modified

--- a/scm_source/cli.py
+++ b/scm_source/cli.py
@@ -1,13 +1,15 @@
 import click
 from clickclick import Action
 from .api import generate_scm_source
+import sys
 
 
 @click.command()
 @click.option('-f', '--file', metavar='PATH', default='scm-source.json', help='file path to write to')
 @click.option('--author', metavar='USER', envvar='USER', help='author of the scm-source.json (default: current $USER)')
 @click.argument('directory', nargs=-1, type=click.Path(exists=True))
-def main(file, author, directory):
+@click.option('--fail-on-modified', help="fails on locally modified code tree", is_flag=True)
+def main(file, author, directory, fail_on_modified):
     if not directory:
         directory = None
     elif len(directory) == 1:
@@ -15,6 +17,8 @@ def main(file, author, directory):
     else:
         raise click.UsageError('At most one directory can be given')
     with Action('Generating {}..'.format(file)) as act:
-        locally_modified = generate_scm_source(file, author, directory)
-        if locally_modified:
-            act.warning('LOCALLY MODIFIED')
+        try:
+            if generate_scm_source(file, author, directory, fail_on_modified):
+                act.warning('LOCALLY MODIFIED')
+        except RuntimeError as e:
+            act.fatal_error(str(e))

--- a/scm_source/cli.py
+++ b/scm_source/cli.py
@@ -1,7 +1,6 @@
 import click
 from clickclick import Action
 from .api import generate_scm_source
-import sys
 
 
 @click.command()

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ def read_version(package):
             if line.startswith('__version__ = '):
                 return line.split()[-1].strip().strip("'")
 
+
 __version__ = read_version('scm_source')
 
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -23,3 +23,11 @@ def test_generate_scm_source_dir_not_exists(monkeypatch):
     monkeypatch.setattr('os.path.isdir', lambda x: False)
     with pytest.raises(FileNotFoundError):
         generate_scm_source('test.json', 'JohnDoe', 'does-not-exist')
+
+
+def test_generate_scm_source_throws_on_fail_on_modified(monkeypatch):
+    def mocked_check_output(x):
+        return b'NONEMPTY STRING'
+    monkeypatch.setattr('subprocess.check_output', mocked_check_output)
+    with pytest.raises(RuntimeError):
+        generate_scm_source('', '', fail_on_modified=True)

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2,6 +2,7 @@ import os
 import pytest
 from scm_source import generate_scm_source
 
+
 def test_generate_scm_source(monkeypatch):
     monkeypatch.setattr('subprocess.check_output', lambda x: b'test')
     generate_scm_source('test.json', 'JohnDoe')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -4,14 +4,14 @@ from click.testing import CliRunner
 from scm_source.cli import main
 
 def test_main(monkeypatch):
-    monkeypatch.setattr('scm_source.cli.generate_scm_source', lambda x, y, z: True)
+    monkeypatch.setattr('scm_source.cli.generate_scm_source', lambda x, y, z, q: True)
     runner = CliRunner()
     result = runner.invoke(main, [], catch_exceptions=False)
     assert 'Generating scm-source.json.. LOCALLY MODIFIED' in result.output
 
 
 def test_directory_arg(monkeypatch):
-    def generate_scm_source(x, y, directory):
+    def generate_scm_source(x, y, directory, fatal_on_modified):
         assert 'mydir' == directory
         return False
     monkeypatch.setattr('scm_source.cli.generate_scm_source', generate_scm_source)
@@ -39,3 +39,26 @@ def test_directory_multiple_args(monkeypatch):
         result = runner.invoke(main, ['foo', 'bar'], catch_exceptions=False)
     assert 'At most one directory can be given' in result.output
     assert 2 == result.exit_code
+
+
+def test_fail_on_modified_with_flag(monkeypatch):
+    def mocked_generate_scm_source(x, y, z, fail_on_modified):
+        raise RuntimeError
+    monkeypatch.setattr('scm_source.cli.generate_scm_source', mocked_generate_scm_source)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.makedirs('foo')
+        result = runner.invoke(main, ['--fail-on-modified', 'foo'])
+    assert result.exit_code != 0
+
+
+def test_no_fail_on_modified_without_flag(monkeypatch):
+    def mocked_generate_scm_source(x, y, z, fail_on_modified):
+        return 'non empty status'
+    monkeypatch.setattr('scm_source.cli.generate_scm_source', mocked_generate_scm_source)
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        os.makedirs('foo')
+        result = runner.invoke(main, ['foo'])
+    assert result.exit_code == 0
+    assert 'Generating scm-source.json.. LOCALLY MODIFIED' in result.output

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,6 +3,7 @@ from click.testing import CliRunner
 
 from scm_source.cli import main
 
+
 def test_main(monkeypatch):
     monkeypatch.setattr('scm_source.cli.generate_scm_source', lambda x, y, z, q: True)
     runner = CliRunner()


### PR DESCRIPTION
I've added an optional boolean flag `--fail-on-modified` to make the script fail with a non-zero exit status in the case of dirty code tree. Current behaviour is still intact if the flag is not passed.

I've also fixed a flake8 issue in `setup.py` because it failed the test on Travis.

Closes #9