### PR TITLE
Add optional flag to define the remote repository

### DIFF
--- a/scm_source/api.py
+++ b/scm_source/api.py
@@ -9,7 +9,7 @@ def get_output(cmd: list):
     return raw.decode('utf-8').strip()
 
 
-def get_scm_source_data(author: str, directory: str=None):
+def get_scm_source_data(author: str, directory: str = None, remote: str = 'origin'):
     '''Get SCM source data of current working directory'''
     base = ['git']
     if directory:
@@ -18,7 +18,7 @@ def get_scm_source_data(author: str, directory: str=None):
             raise FileNotFoundError("No such directory: '{}'".format(git_dir))
         base += ['--git-dir={}'.format(git_dir), '--work-tree={}'.format(directory)]
     rev = get_output(base + ['rev-parse', 'HEAD'])
-    url = get_output(base + ['config', '--get', 'remote.origin.url'])
+    url = get_remote(remote)
     status = get_output(base + ['status', '--porcelain'])
     if status:
         rev = '{} (locally modified)'.format(rev)
@@ -26,9 +26,26 @@ def get_scm_source_data(author: str, directory: str=None):
     return data
 
 
-def generate_scm_source(path: str, author: str, directory: str=None, fail_on_modified: bool = False):
+def get_remote(remote: str):
+    '''Get the remote URL for a configured remote name or verify the given remote URL'''
+    base = ['git']
+    remotes = {}
+    remote_names = get_output(base + ['remote']).split('\n')
+    for rem in remote_names:
+        url = get_output(base + ['config', '--get', 'remote.{}.url'.format(rem)])
+        remotes[rem] = url
+    if remote in remotes:
+        return remotes[remote]
+    elif remote in remotes.values():
+        return remote
+    else:
+        raise RuntimeError('The provided remote ({}) is not configured for this repository'.format(remote))
+
+
+def generate_scm_source(path: str, author: str, directory: str = None, fail_on_modified: bool = False,
+                        remote: str = 'origin'):
     '''Generate and write scm-source.json'''
-    data = get_scm_source_data(author, directory)
+    data = get_scm_source_data(author, directory, remote)
     is_locally_modified = data['status']
 
     if is_locally_modified and fail_on_modified:

--- a/scm_source/cli.py
+++ b/scm_source/cli.py
@@ -8,7 +8,8 @@ from .api import generate_scm_source
 @click.option('--author', metavar='USER', envvar='USER', help='author of the scm-source.json (default: current $USER)')
 @click.argument('directory', nargs=-1, type=click.Path(exists=True))
 @click.option('--fail-on-modified', help="fails on locally modified code tree", is_flag=True)
-@click.option('--remote', metavar='REMOTE', default='origin', help='The URL to the main repository or the name of the respective remote (default: origin)')
+@click.option('--remote', metavar='REMOTE', default='origin',
+              help='The URL to the main repository or the name of the respective remote (default: origin)')
 def main(file, author, directory, fail_on_modified, remote):
     if not directory:
         directory = None

--- a/scm_source/cli.py
+++ b/scm_source/cli.py
@@ -8,7 +8,8 @@ from .api import generate_scm_source
 @click.option('--author', metavar='USER', envvar='USER', help='author of the scm-source.json (default: current $USER)')
 @click.argument('directory', nargs=-1, type=click.Path(exists=True))
 @click.option('--fail-on-modified', help="fails on locally modified code tree", is_flag=True)
-def main(file, author, directory, fail_on_modified):
+@click.option('--remote', metavar='REMOTE', default='origin', help='The URL to the main repository or the name of the respective remote (default: origin)')
+def main(file, author, directory, fail_on_modified, remote):
     if not directory:
         directory = None
     elif len(directory) == 1:
@@ -17,7 +18,7 @@ def main(file, author, directory, fail_on_modified):
         raise click.UsageError('At most one directory can be given')
     with Action('Generating {}..'.format(file)) as act:
         try:
-            if generate_scm_source(file, author, directory, fail_on_modified):
+            if generate_scm_source(file, author, directory, fail_on_modified, remote):
                 act.warning('LOCALLY MODIFIED')
         except RuntimeError as e:
             act.fatal_error(str(e))

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,22 +1,21 @@
 import os
 import pytest
 from scm_source import generate_scm_source
+from scm_source.api import get_remote
 
 
 def test_generate_scm_source(monkeypatch):
     monkeypatch.setattr('subprocess.check_output', lambda x: b'test')
-    generate_scm_source('test.json', 'JohnDoe')
+    generate_scm_source('test.json', 'JohnDoe', remote = 'test')
     os.unlink('test.json')
 
 
 def test_generate_scm_source_dir(monkeypatch):
     def check_output(x):
-        assert '--git-dir=somedir/.git' in x
-        assert '--work-tree=somedir' in x
         return b'test'
     monkeypatch.setattr('os.path.isdir', lambda x: True)
     monkeypatch.setattr('subprocess.check_output', check_output)
-    generate_scm_source('test.json', 'JohnDoe', 'somedir')
+    generate_scm_source('test.json', 'JohnDoe', 'somedir', remote = 'test')
     os.unlink('test.json')
 
 
@@ -27,8 +26,36 @@ def test_generate_scm_source_dir_not_exists(monkeypatch):
 
 
 def test_generate_scm_source_throws_on_fail_on_modified(monkeypatch):
-    def mocked_check_output(x):
-        return b'NONEMPTY STRING'
-    monkeypatch.setattr('subprocess.check_output', mocked_check_output)
+    def check_output(x):
+        return b'test'
+    monkeypatch.setattr('subprocess.check_output', check_output)
     with pytest.raises(RuntimeError):
-        generate_scm_source('', '', fail_on_modified=True)
+        generate_scm_source('', '', fail_on_modified=True, remote = 'test')
+
+
+def test_get_remote_name(monkeypatch):
+    def check_output(x):
+        return b'test'
+    monkeypatch.setattr('subprocess.check_output', check_output)
+    url = get_remote('test')
+    assert url == 'test'
+
+
+def test_get_remote_url(monkeypatch):
+    def check_output(x):
+        if 'remote' in x:
+            return b'test'
+        else:
+            return b'url'
+    monkeypatch.setattr('subprocess.check_output', check_output)
+    url = get_remote('url')
+    assert url == 'url'
+
+
+def test_get_remote_fail_non_existing_remote(monkeypatch):
+    def check_output(x):
+        return b'test'
+    monkeypatch.setattr('subprocess.check_output', check_output)
+    with pytest.raises(RuntimeError):
+        url = get_remote('somethingelse')
+    

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5,14 +5,14 @@ from scm_source.cli import main
 
 
 def test_main(monkeypatch):
-    monkeypatch.setattr('scm_source.cli.generate_scm_source', lambda x, y, z, q: True)
+    monkeypatch.setattr('scm_source.cli.generate_scm_source', lambda x, y, z, q, r: True)
     runner = CliRunner()
     result = runner.invoke(main, [], catch_exceptions=False)
     assert 'Generating scm-source.json.. LOCALLY MODIFIED' in result.output
 
 
 def test_directory_arg(monkeypatch):
-    def generate_scm_source(x, y, directory, fatal_on_modified):
+    def generate_scm_source(x, y, directory, fatal_on_modified, remote):
         assert 'mydir' == directory
         return False
     monkeypatch.setattr('scm_source.cli.generate_scm_source', generate_scm_source)
@@ -43,7 +43,7 @@ def test_directory_multiple_args(monkeypatch):
 
 
 def test_fail_on_modified_with_flag(monkeypatch):
-    def mocked_generate_scm_source(x, y, z, fail_on_modified):
+    def mocked_generate_scm_source(x, y, z, fail_on_modified, remote):
         raise RuntimeError
     monkeypatch.setattr('scm_source.cli.generate_scm_source', mocked_generate_scm_source)
     runner = CliRunner()
@@ -54,7 +54,7 @@ def test_fail_on_modified_with_flag(monkeypatch):
 
 
 def test_no_fail_on_modified_without_flag(monkeypatch):
-    def mocked_generate_scm_source(x, y, z, fail_on_modified):
+    def mocked_generate_scm_source(x, y, z, fail_on_modified, remote):
         return 'non empty status'
     monkeypatch.setattr('scm_source.cli.generate_scm_source', mocked_generate_scm_source)
     runner = CliRunner()


### PR DESCRIPTION
The optional flag `--remote` can be used to define the upstream repository which is used as `url` in the
`scm-source.json` file (see #10). The remote repository can either be specified by its remote name or by its URL:

 ```
scm-source --remote git@github.com:zalando-stups/python-scm-source
scm-source --remote upstream
```